### PR TITLE
fix problem with quoted keys in url map configuration

### DIFF
--- a/main.bal
+++ b/main.bal
@@ -37,6 +37,7 @@ isolated function mapToInternalUrl(string url) returns string {
         string strippedKey = key;
 
         // remove enclosing quotes if necessary
+        // FIXME: This is a workaround for a possible bug in Ballerina. Can be removed if the bug is fixed.
         if key[0] == "\"" || key[0] == "'" {
             strippedKey = key.substring(1, key.length() - 1);
         }

--- a/main.bal
+++ b/main.bal
@@ -34,7 +34,14 @@ isolated function mapToInternalUrl(string url) returns string {
     // apply all replacements specified in the url map, keys are interpreted as regex
     var replacedUrl = url;
     foreach var key in internalUrlMap.keys() {
-        replacedUrl = regex:replaceFirst(url, key, internalUrlMap.get(key));
+        string strippedKey = key;
+
+        // remove enclosing quotes if necessary
+        if key[0] == "\"" || key[0] == "'" {
+            strippedKey = key.substring(1, key.length() - 1);
+        }
+        
+        replacedUrl = regex:replaceFirst(url, strippedKey, internalUrlMap.get(key));
     }
     return replacedUrl;
 }


### PR DESCRIPTION
When a TOML file contains keys that are enclosed in quotes and you load this file into a map, the quotes are still present in the keys of the map. This leads to problems when you use one of those keys in regex.