### PR TITLE
fix regular expression to match environment variable

### DIFF
--- a/main.bal
+++ b/main.bal
@@ -71,12 +71,8 @@ configurable string host = "http://localhost:" + serverPort.toString();
 # + return - the configured host base path (including protocol and port)
 function getHost() returns string {
     string h = os:getEnv("QHANA_HOST");
-    if (regex:matches(h, "^https?:\\/\\/.*")) {
-        do {
-            return h;
-        } on fail error err {
-            // error should never happen if regex is correct...
-        }
+    if (regex:matches(h, "^https?:\\/\\/.*$")) {
+        return h;
     }
     return host;
 }

--- a/main.bal
+++ b/main.bal
@@ -71,7 +71,7 @@ configurable string host = "http://localhost:" + serverPort.toString();
 # + return - the configured host base path (including protocol and port)
 function getHost() returns string {
     string h = os:getEnv("QHANA_HOST");
-    if (regex:matches(h, "^https?://")) {
+    if (regex:matches(h, "^https?:\\/\\/.*")) {
         do {
             return h;
         } on fail error err {


### PR DESCRIPTION
The regular expression did not match strings that represent URLs.

For example `http://host.docker.internal:9090` was not recognized and the default host `http://localhost:9090` was used instead.
__Without__ telling the user the reason!

Maybe there should be a warning, when the environment variable is set (not empty) but did did not match the regular expression?