### PR TITLE
Add proxy to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,15 @@ ADD --chown=ballerina https://github.com/ufoscout/docker-compose-wait/releases/d
 # make scripts executable
 RUN chmod +x /app/wait && chmod +x /app/start-docker.sh
 
+# install proxy
+ADD https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/install_proxy.sh install_proxy.sh
+RUN chmod +x install_proxy.sh && ./install_proxy.sh
+
+# add localhost proxy files
+ADD --chown=ballerina https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/Caddyfile.template Caddyfile.template
+ADD --chown=ballerina https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/start_proxy.sh start_proxy.sh
+RUN chmod +x start_proxy.sh
+
 # switch to unpriviledged user
 USER ballerina
 
@@ -55,5 +64,4 @@ USER ballerina
 ENV PATH="${PATH}:/app/liquibase"
 
 # run backend
-CMD /app/start-docker.sh
-
+CMD ./start_proxy.sh && /app/start-docker.sh

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Environment variables to configure the backend with:
 | QHANA_CORS_DOMAINS | `http://localhost:4200` | Domains for which cors requests are allowed. Entries are separated by any whitespace. |
 | QHANA_WATCHER_INTERVALLS | `1 10 10 5 60` | Configuration for the result watcher intervalls. Event entries are intervalls (in seconds) and odd entries specify after how many iterations the next intervall in the list is used. |
 | QHANA_URL_MAPPING | `{"(?<=^\|https?://)localhost(:[0-9]+)?": "host.docker.internal$1"}` | A map of rewrite rules for plugin result URLs. The map is a JSON object whose keys are regex patterns and whose values are the replacement strings for these patterns. All rules are applied to an URL without a guaranteed order. |
+| LOCALHOST_PROXY_PORTS | `:1234 :2345` | Alternative to QHANA_URL_MAPPING that can be used with the docker container. Forwards requests that go to the specified ports to the host machine.
 | QHANA_PLUGINS | `["http://localhost:5005/plugins/hello-world@v0-1-0/", "http://localhost:5005/plugins/entity-filter@v0-1-0/"]` | A list (JSON list/array) of plugin URLs. |
 | QHANA_PLUGIN_RUNNERS | `["http://localhost:5005"]` | The list (JSON list/array) of plugin runner URLs. |
 


### PR DESCRIPTION
This PR adds a proxy to the docker image to redirect requests to the host machine for specified ports.