### PR TITLE
Fix Dockerfile: start_proxy.sh not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,4 +66,4 @@ USER ballerina
 ENV PATH="${PATH}:/app/liquibase"
 
 # run backend
-CMD /app/start_proxy.sh && /app/start-docker.sh
+CMD (cd /app && ./start_proxy.sh) && /app/start-docker.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ RUN chmod +x install_proxy.sh && ./install_proxy.sh
 
 # add localhost proxy files
 ADD --chown=ballerina https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/Caddyfile.template Caddyfile.template
-ADD --chown=ballerina https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/start_proxy.sh start_proxy.sh
-RUN chmod +x start_proxy.sh
+ADD --chown=ballerina https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/start_proxy.sh /app/start_proxy.sh
+RUN chmod +x /app/start_proxy.sh
 
 # switch to unpriviledged user
 USER ballerina
@@ -64,4 +64,4 @@ USER ballerina
 ENV PATH="${PATH}:/app/liquibase"
 
 # run backend
-CMD ./start_proxy.sh && /app/start-docker.sh
+CMD /app/start_proxy.sh && /app/start-docker.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,17 @@ LABEL org.opencontainers.image.source="https://github.com/UST-QuAntiL/qhana-back
 
 RUN apt-get -y update && apt-get install -y sqlite3 unzip zip
 
+WORKDIR /app
+
+# install proxy
+ADD https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/install_proxy.sh install_proxy.sh
+RUN chmod +x install_proxy.sh && ./install_proxy.sh
+
+# add localhost proxy files
+ADD --chown=ballerina https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/Caddyfile.template Caddyfile.template
+ADD --chown=ballerina https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/start_proxy.sh start_proxy.sh
+RUN chmod +x start_proxy.sh
+
 # create unpriviledged user
 RUN useradd ballerina
 
@@ -47,15 +58,6 @@ ADD --chown=ballerina https://github.com/ufoscout/docker-compose-wait/releases/d
 
 # make scripts executable
 RUN chmod +x /app/wait && chmod +x /app/start-docker.sh
-
-# install proxy
-ADD https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/install_proxy.sh install_proxy.sh
-RUN chmod +x install_proxy.sh && ./install_proxy.sh
-
-# add localhost proxy files
-ADD --chown=ballerina https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/Caddyfile.template Caddyfile.template
-ADD --chown=ballerina https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/start_proxy.sh /app/start_proxy.sh
-RUN chmod +x /app/start_proxy.sh
 
 # switch to unpriviledged user
 USER ballerina


### PR DESCRIPTION
The `backend` docker container exits with the error `/bin/sh: 1: ./start_proxy.sh: not found` when deployed with `docker-compose up`. 
The `start_proxy.sh` script seems to be put into the `/app/data` directory, which is overwritten (I think) on startup. Moving the script up one directory works for me.

### Edit:
`/app/data` is a mounted directory. Therefore, the contents (`start_proxy.sh`) of this directory are missing after startup.

https://github.com/UST-QuAntiL/qhana-backend/blob/e52ee9a46555f13bd95cb02ef0ab41b60fb37064/docker-compose.yml#L8-L9