### PR TITLE
fix IndexOutOfRange error

### DIFF
--- a/modules/database/export.bal
+++ b/modules/database/export.bal
@@ -341,7 +341,7 @@ public isolated transactional function getExperimentDBExport(ExperimentFull expe
         }
         int counter = 0;
         foreach TimelineStepFull timelineStepDb in timelineStepListDb {
-            if config.restriction == "STEPS" {
+            if config.restriction == "STEPS" && counter < stepList.length() {
                 // skip steps not in stepList 
                 if timelineStepDb.sequence == stepList[counter] {
                     counter += 1;
@@ -376,7 +376,7 @@ public isolated transactional function getExperimentDBExport(ExperimentFull expe
     }
 
     experimentDataList = check getExportDataList(experiment.experimentId, config, dataIdList);
-
+    
     return {
         experiment: {name: experiment.name, description: experiment.description, templateId: experiment?.templateId},
         timelineSteps: timelineSteps,


### PR DESCRIPTION
The `getExperimentDBExport` function iterates over an array of timline steps and skips the ones that are not in the `stepList`. To skip steps, it is compared if `timelineStepDb.sequence == stepList[counter]`. However, it is never checked if `counter < stepList.length()` resulting in a `IndexOutOfRange` error when the sequence number of the last timline step is not in `stepList`.