### PR TITLE
Add a data-type filter query param to data page endpoint

### DIFF
--- a/Dependencies.toml
+++ b/Dependencies.toml
@@ -64,7 +64,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.0"
+version = "2.9.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -212,7 +212,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -267,6 +267,18 @@ dependencies = [
 ]
 modules = [
 	{org = "ballerina", packageName = "os", moduleName = "os"}
+]
+
+[[package]]
+org = "ballerina"
+name = "regex"
+version = "1.4.3"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.string"}
+]
+modules = [
+	{org = "ballerina", packageName = "regex", moduleName = "regex"}
 ]
 
 [[package]]
@@ -388,6 +400,7 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
 	{org = "ballerina", name = "os"},
+	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "sql"},
 	{org = "ballerina", name = "task"},
 	{org = "ballerina", name = "time"},

--- a/main.bal
+++ b/main.bal
@@ -522,7 +522,7 @@ service / on new http:Listener(serverPort) {
     # + sort - 1 for asc sort, -1 for desc sort by name and version
     # + search - search keyword in name, data type and content type (insensitive)
     # + return - the paginated list of data resources
-    resource function get experiments/[int experimentId]/data(boolean? all\-versions, string? search, int page = 0, int item\-count = 10, int? sort = 1) returns ExperimentDataListResponse|http:NotFound|http:InternalServerError|http:BadRequest {
+    resource function get experiments/[int experimentId]/data(boolean? all\-versions, string? search, string? data\-type, int page = 0, int item\-count = 10, int? sort = 1) returns ExperimentDataListResponse|http:NotFound|http:InternalServerError|http:BadRequest {
         boolean includeAllVersions = all\-versions == true || all\-versions == ();
         int intSort = (sort is ()) ? 1 : sort;
         string searchString = (search is ()) ? "" : search;
@@ -541,13 +541,13 @@ service / on new http:Listener(serverPort) {
         database:ExperimentDataFull[] data;
 
         transaction {
-            dataCount = check database:getExperimentDataCount(experimentId, searchString, all = includeAllVersions);
+            dataCount = check database:getExperimentDataCount(experimentId, searchString, all = includeAllVersions, dataType = data\-type);
             if (offset >= dataCount) {
                 // page is out of range!
                 check commit;
                 return <http:NotFound>{};
             } else {
-                data = check database:getDataList(experimentId, searchString, all = includeAllVersions, 'limit = item\-count, offset = offset, sort = intSort);
+                data = check database:getDataList(experimentId, searchString, all = includeAllVersions, dataType = data\-type, 'limit = item\-count, offset = offset, sort = intSort);
                 check commit;
             }
         } on fail error err {


### PR DESCRIPTION
Filtering by the data type of the stored data will allow decluttering the "choose data" dialog in the QHAna UI.