### PR TITLE
Feature/docker update

### DIFF
--- a/Dependencies.toml
+++ b/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.7.0"
+distribution-version = "2201.7.2"
 
 [[package]]
 org = "ballerina"
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -64,7 +64,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ RUN apt-get -y update && apt-get install unzip
 WORKDIR /app
 
 # install ballerina
-ARG BAL_VERSION="2201.7.0-swan-lake"
-RUN wget --no-verbose https://dist.ballerina.io/downloads/2201.7.0/ballerina-${BAL_VERSION}.zip
-RUN unzip ballerina-${BAL_VERSION}
-ENV PATH="${PATH}:/app/ballerina-${BAL_VERSION}/bin"
+ARG BAL_VERSION="2201.7.2"
+RUN wget --no-verbose https://dist.ballerina.io/downloads/${BAL_VERSION}/ballerina-${BAL_VERSION}-swan-lake.zip
+RUN unzip ballerina-${BAL_VERSION}-swan-lake
+ENV PATH="${PATH}:/app/ballerina-${BAL_VERSION}-swan-lake/bin"
 
 # install liquibase
 RUN wget --no-verbose https://github.com/liquibase/liquibase/releases/download/v4.11.0/liquibase-4.11.0.zip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       args:
-        BAL_VERSION: 2201.7.0-swan-lake
+        BAL_VERSION: "2201.7.2"
     image: qhana-backend
     volumes:
       - ./experimentData:/app/data

--- a/main.bal
+++ b/main.bal
@@ -75,6 +75,7 @@ function getPort() returns int {
             // error should never happen if regex is correct...
         }
     }
+    log:printInfo("Binding to port " + port.toBalString());
     return port;
 }
 

--- a/modules/database/database.bal
+++ b/modules/database/database.bal
@@ -1012,7 +1012,7 @@ public isolated transactional function getStepOutputData(int|TimelineStepFull st
 public isolated transactional function saveTimelineStepOutputData(int stepId, int experimentId, ExperimentData[] outputData) returns error? {
     sql:ParameterizedQuery baseQuery = `INSERT INTO ExperimentData (experimentId, name, version, location, type, contentType) VALUES `;
     sql:ParameterizedQuery[] dataQuery = from var d in outputData
-        select `(${experimentId}, ${d.name}, (SELECT version FROM (SELECT count(*) + 1 AS version FROM ExperimentData WHERE name = ${d.name}) subquery), ${d.location}, ${d.'type}, ${d.contentType})`;
+        select `(${experimentId}, ${d.name}, (SELECT version FROM (SELECT coalesce(max(version) + 1, 1) AS version FROM ExperimentData WHERE name = ${d.name} AND experimentId = ${experimentId}) subquery), ${d.location}, ${d.'type}, ${d.contentType})`;
 
     foreach var insertData in dataQuery {
         var result = check experimentDB->execute(sql:queryConcat(baseQuery, insertData));


### PR DESCRIPTION
- Update docker container (use newest ballerina version)
- Fix data versioning. Versions are now counted per experiment. (This patch will not reuse version numbers that were skipped because previously versions were counted globally)